### PR TITLE
[G2M] incorporate adapter inside widget-studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@babel/eslint-parser": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
-    "@eqworks/chart-system": "EQWorks/chart-system#widget/widget-adapter",
+    "@eqworks/chart-system": "^0.5.2",
     "@eqworks/common-login": "^0.8.0-alpha.5",
     "@eqworks/lumen-ui": "^1.0.0",
     "@eqworks/react-labs": "^1.12.1-alpha.5",

--- a/src/adapter/chart-system/nivo.js
+++ b/src/adapter/chart-system/nivo.js
@@ -1,0 +1,98 @@
+import { createElement, useMemo } from 'react'
+import PropTypes from 'prop-types'
+
+import { BarChart, PieChart, LineChart, ScatterChart } from '@eqworks/chart-system'
+
+const charts = {
+  bar: BarChart,
+  line: LineChart,
+  pie: PieChart,
+  scatter: ScatterChart,
+}
+
+const WidgetAdapter = ({ rows, config: { type, options } }) => {
+
+  const shuffledRows = useMemo(() => rows.sort(() => Math.random() - Math.random()), [rows])
+
+  const adaptedData = useMemo(() => {
+    if (type === 'bar' || type === 'pie' || type === 'scatter') {
+      return shuffledRows.slice(0, 15)
+    }
+    else if (type === 'line') {
+      return rows.slice(0, 15)
+    }
+    throw new Error
+  }, [rows, shuffledRows, type])
+
+  const adaptedConfig = useMemo(() => {
+    if (type === 'bar') {
+      return {
+        data: adaptedData,
+        groupMode: options.stack ? 'stacked' : 'grouped',
+        ...options.indexBy && { indexBy: options.indexBy },
+        ...options.group ?
+          {
+            groupByKey: options.groupBy,
+            valueKey: options.keys[0],
+          }
+          :
+          {
+            keys: options.keys,
+          },
+        // axisBottomLegendLabel: ???,
+        ...options.group && options.keys[0] && {
+          axisLeftLegendLabel: options.keys[0],
+        },
+      }
+    }
+    else if (type === 'line') {
+      return {
+        // title={title}
+        data: adaptedData,
+        ...options.indexByValue &&
+        {
+          indexBy: options.indexBy,
+        },
+        yKeys: options.y,
+        xKey: options.x,
+        xScale: { type: 'point' },
+        indexByValue: options.indexByValue,
+        axisBottomLegendLabel: options.x,
+        axisLeftLegendLabel: options.y.join(', '),
+      }
+    }
+    else if (type === 'pie') {
+      return {
+        //   title:title ,
+        data: adaptedData,
+        dataKey: options.keys[0], // TODO support multi..?
+        indexBy: options.indexBy,
+        isDonut: options.donut,
+      }
+    }
+    else if (type === 'scatter') {
+      return {
+        //   title:title ,
+        data: adaptedData,
+        xKey: options.x,
+        yKeys: options.y,
+        indexBy: options.indexBy,
+      }
+    }
+  }, [adaptedData, options, type])
+
+  return createElement(charts[type], { ...adaptedConfig })
+}
+
+WidgetAdapter.propTypes = {
+  rows: PropTypes.array,
+  columns: PropTypes.array,
+  config: PropTypes.object,
+}
+WidgetAdapter.default = {
+  rows: [],
+  columns: [],
+  config: {},
+}
+
+export default WidgetAdapter

--- a/src/adapter/index.js
+++ b/src/adapter/index.js
@@ -1,0 +1,1 @@
+export { default as NivoAdapter } from './chart-system/nivo'

--- a/src/widget/adapter-associations.js
+++ b/src/widget/adapter-associations.js
@@ -1,0 +1,8 @@
+import { NivoAdapter } from '../adapter'
+
+export default {
+  bar: NivoAdapter,
+  pie: NivoAdapter,
+  scatter: NivoAdapter,
+  line: NivoAdapter,
+}

--- a/src/widget/index.js
+++ b/src/widget/index.js
@@ -7,11 +7,12 @@ import { Typography } from '@eqworks/lumen-ui'
 
 import { requestData, requestConfig } from '../util/fetch'
 import styles from './styles'
+import adapters from './adapter-associations'
 
 // put styles in separate file for readability
 const useStyles = makeStyles(styles)
 
-const Widget = ({ id, studioConfig, studioData, adapter }) => {
+const Widget = ({ id, studioConfig, studioData }) => {
 
   const classes = useStyles()
 
@@ -59,7 +60,7 @@ const Widget = ({ id, studioConfig, studioData, adapter }) => {
         {
           // pass data + config to the adapter of choice
           createElement(
-            adapter,
+            adapters[config.type],
             {
               ...{ rows, columns, config }
             }
@@ -78,7 +79,6 @@ Widget.propTypes = {
   studioConfig: PropTypes.object,
   studioData: PropTypes.object,
   id: PropTypes.string,
-  adapter: PropTypes.object,
 }
 
 export default Widget

--- a/stories/widget.stories.js
+++ b/stories/widget.stories.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { WidgetAdapter as NivoAdapter } from '@eqworks/chart-system'
 
 import sampleConfigs from './sample-configs'
 import { Widget, WidgetStudio } from '../src'
@@ -17,7 +16,7 @@ storiesOf('Dashboard-esque example')
         Object.keys(sampleConfigs).map(id =>
           <div key={id}>
             <WidgetStudio>
-              <Widget adapter={NivoAdapter} {...{ id }} />
+              <Widget {...{ id }} />
             </WidgetStudio>
           </div>
         )
@@ -29,12 +28,12 @@ storiesOf('Undefined widget')
   // showcase behaviour without explicit widget ID
   .add('In studio', () => (
     <WidgetStudio>
-      <Widget adapter={NivoAdapter} />
+      <Widget />
     </WidgetStudio>
   ))
   // demonstrate incorrect component usage
   .add('Standalone (not allowed)', () => (
-    <Widget adapter={NivoAdapter} />
+    <Widget />
   ))
 
 // for each non-empty sample config,
@@ -49,7 +48,7 @@ Object.entries(sampleConfigs).forEach(([id, config]) => {
     storiesOf('Defined widget wrapped in studio', module)
       .add(label, () => (
         <WidgetStudio>
-          <Widget {...{ id }} adapter={NivoAdapter} />
+          <Widget {...{ id }} />
         </WidgetStudio >
       ))
 
@@ -57,7 +56,7 @@ Object.entries(sampleConfigs).forEach(([id, config]) => {
     storiesOf('Defined widget')
       .add(label, () => (
         <div style={styles.outerContainer} >
-          <Widget {...{ id }} adapter={NivoAdapter} />
+          <Widget {...{ id }} />
         </div>
       ))
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2042,9 +2042,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@eqworks/chart-system@EQWorks/chart-system#widget/widget-adapter":
+"@eqworks/chart-system@^0.5.2":
   version "0.5.2"
-  resolved "https://codeload.github.com/EQWorks/chart-system/tar.gz/5d34c90c48da8fc5a63fedae746fb066a97feccc"
+  resolved "https://npm.pkg.github.com/download/@eqworks/chart-system/0.5.2/1338c6f437b68e3cdc94cbc834fb3277921173af4de086e58f506669fda3717d#8d743e29d39edd48e14282750e5261385f91b960"
+  integrity sha512-cC6hRqQ+kJwpknGHScGET+HxeenWn8IfGCZvSyi1WN+zNytAfSrUihwnv2mzRPJK7Wziu+K1w1us8WD0loIf2A==
   dependencies:
     "@nivo/bar" "^0.62.0"
     "@nivo/core" "^0.62.0"


### PR DESCRIPTION
to be merged after #2

---


- Use `src/widget/adapter-associations.js` to map widget types to chart libraries instead of using `adapter` prop in `Widget`
- Moved the Nivo `WidgetAdapter` from `chart-system` to this repo
- Further adapters will be stored in `src/adapter` (ex. `src/adapter/chart-system/plotly`, etc.)