### PR TITLE
[G2M] adapter - PropTypes schema validation, no joi

### DIFF
--- a/src/content/widget-adapter/adapters/chart-system/plotly.js
+++ b/src/content/widget-adapter/adapters/chart-system/plotly.js
@@ -2,48 +2,44 @@ import { PlotlyBarChart, PlotlyPieChart, PlotlyLineChart, PlotlyScatterChart } f
 
 
 export default {
-  bar: [
-    PlotlyBarChart,
-    (data, { options, genericOptions, ...config }) => ({
-      adaptedData: {
-        data,
-        x: config.groupKey,
-        y: Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`))
-      },
-      adaptedConfig: { ...options, ...genericOptions }
+  bar: {
+    component: PlotlyBarChart,
+    adapt: (data, { options, genericOptions, ...config }) => ({
+      data,
+      x: config.groupKey,
+      y: Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)),
+      ...options,
+      ...genericOptions
     })
-  ],
-  line: [
-    PlotlyLineChart,
-    (data, { options, genericOptions, ...config }) => ({
-      adaptedData: {
-        data,
-        x: config.group ? config.groupKey : config.indexKey,
-        y: config.group ? Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)) : Object.keys(config.valueKeys),
-      },
-      adaptedConfig: { ...options, ...genericOptions }
+  },
+  line: {
+    component: PlotlyLineChart,
+    adapt: (data, { options, genericOptions, ...config }) => ({
+      data,
+      x: config.group ? config.groupKey : config.indexKey,
+      y: config.group ? Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)) : Object.keys(config.valueKeys),
+      ...options,
+      ...genericOptions
     })
-  ],
-  pie: [
-    PlotlyPieChart,
-    (data, { options, genericOptions, ...config }) => ({
-      adaptedData: {
-        data,
-        label: config.groupKey,
-        values: Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`))
-      },
-      adaptedConfig: { ...options, ...genericOptions }
+  },
+  pie: {
+    component: PlotlyPieChart,
+    adapt: (data, { options, genericOptions, ...config }) => ({
+      data,
+      label: config.groupKey,
+      values: Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)),
+      ...options,
+      ...genericOptions
     })
-  ],
-  scatter: [
-    PlotlyScatterChart,
-    (data, { options, genericOptions, ...config }) => ({
-      adaptedData: {
-        data,
-        x: config.group ? config.groupKey : config.indexKey,
-        y: config.group ? Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)) : Object.keys(config.valueKeys),
-      },
-      adaptedConfig: { ...options, ...genericOptions }
+  },
+  scatter: {
+    component: PlotlyScatterChart,
+    adapt: (data, { options, genericOptions, ...config }) => ({
+      data,
+      x: config.group ? config.groupKey : config.indexKey,
+      y: config.group ? Object.entries(config.valueKeys).map(([k, { agg }]) => (`${k}_${agg}`)) : Object.keys(config.valueKeys),
+      ...options,
+      ...genericOptions
     })
-  ]
+  }
 }


### PR DESCRIPTION
preparing to remove `joi` dependency and some other changes along the way.

- Change adapter schema to `{ component: [element], adapt: [func] }`
  - (was just an array before: `[component, adapt]`)
- Use `PropTypes` to validate adapter schema instead of third-party library `joi`
- Minor changes in adapter logic for performance and readability