### PR TITLE
[G2M] devops - exclude tailwind css from linguist analysis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# override generated tailwind CSS file so the repo is not assessed to be 99% CSS
+src/styles/index.css linguist-generated


### PR DESCRIPTION
Set `.gitattributes` to ignore 300000-line `tailwind`-generated css file `src/styles/index.css`:

Should fix this problem in the repo sidebar :laughing: :
![image](https://user-images.githubusercontent.com/53827672/137915588-0d58b4ba-eea2-44ee-96bc-41a4c5ee0b61.png)

Don't think this can be tested without merging to `main` beyond using `git check-attr` locally, but [from the docs](https://github.com/github/linguist/blob/master/docs/overrides.md#generated-code) it looks like `linguist-generated` would  be the correct choice.