### PR TITLE
[G2M] Devops/storybook url sticky comment

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,10 +1,16 @@
 name: Chromatic
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
+    outputs:
+      storybook-url: ${{ steps.chromatic-publish.outputs.storybookUrl}}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -19,13 +25,14 @@ jobs:
         with:
           node-version: 14.x
           registry-url: https://npm.pkg.github.com/
-          scope: '@eqworks'
+          scope: "@eqworks"
 
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
 
       - name: Publish to Chromatic
+        id: chromatic-publish
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +40,27 @@ jobs:
           exitZeroOnChanges: true
           autoAcceptChanges: true
         env:
-          STORYBOOK_API_HOST: 'https://api.locus.place'
-          STORYBOOK_API_STAGE: 'dev'
-          STORYBOOK_KEY_WARDEN_HOST: 'https://auth.eqworks.io'
-          STORYBOOK_KEY_WARDEN_STAGE: 'dev'
+          STORYBOOK_API_HOST: "https://api.locus.place"
+          STORYBOOK_API_STAGE: "dev"
+          STORYBOOK_KEY_WARDEN_HOST: "https://auth.eqworks.io"
+          STORYBOOK_KEY_WARDEN_STAGE: "dev"
+
+  storybook-pr-comment:
+    needs: chromatic-deployment
+    if: github.event_name == 'pull_request' && needs.chromatic-deployment.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - env:
+          STORYBOOK_URL_WITH_IFRAME: ${{ needs.chromatic-deployment.outputs.storybook-url }}
+        run: |
+          echo "STORYBOOK_URL=${STORYBOOK_URL_WITH_IFRAME/\/iframe\.html/}" >> $GITHUB_ENV
+          echo "SHA=$(git rev-parse $(cat $GITHUB_EVENT_PATH | jq -r .pull_request.head.sha))" >> $GITHUB_ENV
+
+      - uses: eqworks/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ### 📚 **[Storybook preview](${{ env.STORYBOOK_URL }})** _(updated to ${{ env.SHA }})_


### PR DESCRIPTION
See @github-actions comment below! :)

[As discussed on Slack](https://eqworks.slack.com/archives/CB7557258/p1634647221000100): in the future, will likely package this augmented version of `chromatic.yml` with standard `main.yml`, along with internal utilities for making sticky comments, for common use throughout the org.

However, for now, just keeping it local to `widget-studio` repo (feel free to use elsewhere), and using [EQWorks/sticky-pull-request-comment](https://github.com/EQWorks/sticky-pull-request-comment) (fork of @marocchino).