### PR TITLE
[G2M] UI/improve reset

### DIFF
--- a/src/editor/widget-controls/index.js
+++ b/src/editor/widget-controls/index.js
@@ -45,13 +45,18 @@ const WidgetControls = () => {
   const columns = useStoreState((state) => state.columns)
   const dataReady = useStoreState((state) => state.dataReady)
   const showWidgetControls = useStoreState((state) => state.ui.showWidgetControls)
+  const allowReset = useStoreState((state) => state.ui.allowReset)
 
   const footer = <>
     <div className='flex-1'>
-      {renderButton(<>
-        <Trash size='md' className='mr-1.5 fill-current text-primary-500' />
-        RESET
-      </>, resetWidget)}
+      {renderButton(
+        <>
+          <Trash size='md' className={`mr-1.5 fill-current ${allowReset ? 'text-primary-500' : 'text-secondary-500'}`} />
+          RESET
+        </>,
+        resetWidget,
+        { disabled: !allowReset }
+      )}
     </div>
     {renderButton(
       <>


### PR DESCRIPTION
- adding/improving reset logic
- changing the `defaultState` in the easy-peasy model to discern between states that should and should not be included when resetting
- reset button is now disabled after resetting, and will stay that way for at least 1 second. After that period, the first state change will trigger the reset button to be enabled again. (The reason for the timer is that the reset itself triggers state updates -- admittedly, the timer is technically creating a race condition, will address later) 