### PR TITLE
[G2M] devops - nonblocking chromatic build, add/revise yarn cache action usage

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -27,6 +27,18 @@ jobs:
           registry-url: https://npm.pkg.github.com/
           scope: "@eqworks"
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}
@@ -39,6 +51,7 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitZeroOnChanges: true
           autoAcceptChanges: true
+          exitOnceUploaded: true
         env:
           NODE_ENV: "development"
           STORYBOOK_API_HOST: "https://api.locus.place"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,16 +20,18 @@ jobs:
           node-version: 14.x
           registry-url: https://npm.pkg.github.com/
           scope: '@eqworks'
-          
-      - name: Cache Node Modules
-        uses: actions/cache@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
-          path: node_modules
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+            ${{ runner.os }}-yarn-
 
       - run: yarn install
         env:

--- a/.github/workflows/npm-alpha.yml
+++ b/.github/workflows/npm-alpha.yml
@@ -15,6 +15,19 @@ jobs:
           node-version: 14.x
           registry-url: https://npm.pkg.github.com/
           scope: '@eqworks'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,6 +20,19 @@ jobs:
           node-version: 14.x
           registry-url: https://npm.pkg.github.com/
           scope: '@eqworks'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - run: yarn install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CD_GITHUB_TOKEN }}


### PR DESCRIPTION
notified by github alert on our monthly quota has already been depleted (~half month in). either way not a huge issue, github actions minutes are very cheap ($0.008/minute), and also the fact that we're going to open-source this means that we can be less cautious.

![limit](https://user-images.githubusercontent.com/2837532/153930401-0d46508c-6f37-467a-b2c9-69628ac1583d.png)

still, some low hanging fruits here and there:
- the chromatic build lacks deps caching (this would save non-dep change builds by a good 50s - 1 min)
- we absolutely have no reason to wait for the chromatic side to complete after github side finishes build and upload to chromatic, so `--exit-once-uploaded` (or `exitOnceUploaded` by actions). this cuts the time down by anywhere from 4-6 minutes by eyeballing the diff with [the previous runs](https://github.com/EQWorks/widget-studio/actions?query=workflow%3AChromatic++))

tiny bit greener, why not