### PR TITLE
[G2M] bug fixes for 0.1.1-alpha.2 release

### DIFF
--- a/src/store/model.js
+++ b/src/store/model.js
@@ -233,11 +233,6 @@ export default {
       .map(([name]) => name)
   ),
 
-  stringColumns: computed(
-    [(state) => state.columns],
-    (columns) => columns.filter(({ category }) => category === 'String').map(({ name }) => name)
-  ),
-
   validMapGroupKeys: computed(
     [
       (state) => state.columns,


### PR DESCRIPTION
some of the unique map logic is using `numericColumns`, whose definition had not been updated to match the new `columnsAnalysis` implementation. 