### PR TITLE
[G2M] tweak - always consider columns named 'resolution' as string

### DIFF
--- a/src/constants/columns.js
+++ b/src/constants/columns.js
@@ -19,7 +19,7 @@ export const columnTypeInfo = {
       const res = !isNaN(v)
       return name === undefined
         ? res
-        : res && !name.endsWith('_id')
+        : res && !name.endsWith('_id') && name !== 'resolution'
     },
   },
   [columnTypes.STRING]: {


### PR DESCRIPTION
[ref](https://eqworks.slack.com/archives/GV827LS0M/p1648647437822099)

if a column's name is `resolution`, always infer that column to be a string column