### PR TITLE
[WIP] widgetManager - match types between items and layout

### DIFF
--- a/src/widget-manager.js
+++ b/src/widget-manager.js
@@ -560,7 +560,7 @@ const WidgetManager = ({ wl, cu, dealer, className }) => {
                         onClick={() => {
                           const { id, items, layout } = selectedDashboard
                           const newItems = selection.filter(id => !items.includes(id))
-                          const newLayout = newItems.map(id => ({ x: 0, y: 0, w: 6, h: 4, i: id }))
+                          const newLayout = newItems.map(id => ({ x: 0, y: 0, w: 6, h: 4, i: parseInt(id) }))
                           api.post(`/insights/dashboards/${id}`, {
                             items: items.concat(newItems),
                             layout: layout.concat(newLayout),


### PR DESCRIPTION
Noticed that the `id` type between items and layout are different. Unifying them as`Number` type for consistency.