### PR TITLE
[G2M] Column aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/widget-studio",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/components/linked-select.js
+++ b/src/components/linked-select.js
@@ -5,7 +5,7 @@ import { makeStyles, Icons, Tooltip } from '@eqworks/lumen-labs'
 
 import CustomSelect from '../components/custom-select'
 import CustomButton from '../components/custom-button'
-import ColumnAliasControls from '../controls/editor-mode/components/column-alias-controls'
+import ColumnNameAlias from '../controls/editor-mode/components/column-name-alias'
 import { hasDevAccess  } from '../util/access'
 
 
@@ -113,7 +113,7 @@ const LinkedSelect = ({
     </div>
 
   const renderAliasTextfield = (
-    <ColumnAliasControls
+    <ColumnNameAlias
       value={choice || ''}
       disabled={!choice}
     />

--- a/src/controls/editor-mode/components/column-alias-controls.js
+++ b/src/controls/editor-mode/components/column-alias-controls.js
@@ -58,7 +58,7 @@ const ColumnAliasControls = () => {
   const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
 
   const [localColumnNameAliases, setLocalColumnNameAliases] = useState(columnNameAliases)
-  const [aliasError, setAliasError] = useState(false)
+  const [aliasError, setAliasError] = useState([])
 
   useEffect(() => {
     if (Object.keys(columnNameAliases).length && !aliasesReseted) {
@@ -69,6 +69,19 @@ const ColumnAliasControls = () => {
   const dataColumns = useMemo(() => (
     Object.entries(columnsAnalysis).map(([c, { Icon }]) => ({ key: c, icon: Icon }) )
   ), [columnsAnalysis])
+
+  useEffect(() => {
+    const columnAliases = dataColumns.map(({ key }) => localColumnNameAliases[key] || '')
+    const aliasError = columnAliases.map(alias => {
+      const firstIndex =  columnAliases.findIndex(key => key === alias)
+      const lastIndex =  columnAliases.findLastIndex(key => key === alias)
+      if (!alias || firstIndex === lastIndex) {
+        return false
+      }
+      return true
+    })
+    setAliasError(aliasError)
+  }, [dataColumns, localColumnNameAliases])
 
   return (
     <WidgetControlCard
@@ -95,7 +108,7 @@ const ColumnAliasControls = () => {
             {'Alias'}
           </span>
         </div>
-        {dataColumns?.map((col, i) => {
+        {dataColumns.map((col, i) => {
           return (
             <div key={i} className={classes.row}>
               <div className={classes.columnName}>
@@ -108,16 +121,13 @@ const ColumnAliasControls = () => {
                 value={localColumnNameAliases[col.key]}
                 inputProps={{ placeholder: 'Column title alias' }}
                 onChange={(val) => {
-                  if (Object.values(localColumnNameAliases).includes(val)) {
-                    setAliasError(true)
-                  }
                   setLocalColumnNameAliases({
                     ...localColumnNameAliases,
                     [col.key]: val || '',
                   })
                 }}
-                error={aliasError}
-                helperText={aliasError && 'Alias is already in use!'}
+                error={aliasError[i]}
+                helperText={aliasError[i] && 'Alias is already in use!'}
               />
             </div>
           )})}
@@ -131,6 +141,7 @@ const ColumnAliasControls = () => {
                 columnNameAliases: localColumnNameAliases,
               })
             }}
+            disabled={aliasError.find(key => key === true)}
           >
             submit
           </CustomButton>

--- a/src/controls/editor-mode/components/column-alias-controls.js
+++ b/src/controls/editor-mode/components/column-alias-controls.js
@@ -1,31 +1,48 @@
-import React, { useState, useMemo, createElement } from 'react'
+import React, { useState, useEffect, useMemo, createElement } from 'react'
 
 import { TextField, makeStyles, Icons, getTailwindConfigColor } from '@eqworks/lumen-labs'
 
 import { useStoreState, useStoreActions } from '../../../store'
 import WidgetControlCard from '../../shared/components/widget-control-card'
+import CustomButton from '../../../components/custom-button'
 import cardTypes from '../../../constants/card-types'
 
 
 const classes = makeStyles({
   row: {
     display: 'grid',
+    alignItems: 'center',
     gridTemplateColumns: '50% 50%',
     marginBottom: '0.25rem',
-    gap: '0.25rem',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: '0.714rem',
+    fontWeight: 700,
+    color: getTailwindConfigColor('secondary-500'),
+    padding: '0rem 0.7rem 0.25rem 0.2rem',
+  },
+  headerIcon: {
+    height: '0.714rem !important',
+    marginRight: '0.4rem',
   },
   columnName: {
     display: 'flex',
     gap: '0.5rem',
     alignItems: 'center',
     fontSize: '0.786rem',
+    overflowWrap: 'anywhere',
     color: getTailwindConfigColor('secondary-800'),
     backgroundColor: getTailwindConfigColor('secondary-100'),
     borderRadius: '0.25rem',
     padding: '0.375rem',
+    marginRight: '0.25rem',
   },
-  colKey: {
-    overflow: 'hidden',
+  button: {
+    marginTop: '.5rem',
+    display: 'flex',
+    justifyContent: 'flex-end',
   },
 })
 
@@ -34,17 +51,20 @@ const textfieldClasses = Object.freeze({
 })
 
 const ColumnAliasControls = () => {
-  // const update = useStoreActions(actions => actions.update)
   const userUpdate = useStoreActions(actions => actions.userUpdate)
 
-  // const valueKeys = useStoreState((state) => state.valueKeys)
   const columnsAnalysis = useStoreState((state) => state.columnsAnalysis)
-  const columnNameAliases = useStoreState((state) => state.columnNameAliases || {})
-  // const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
-  // const widgetControlCardEdit = useStoreState((state) => state.widgetControlCardEdit)
+  const columnNameAliases = useStoreState((state) => state.columnNameAliases)
+  const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
 
   const [localColumnNameAliases, setLocalColumnNameAliases] = useState(columnNameAliases)
   const [aliasError, setAliasError] = useState(false)
+
+  useEffect(() => {
+    if (Object.keys(columnNameAliases).length && !aliasesReseted) {
+      setLocalColumnNameAliases(columnNameAliases)
+    }
+  }, [columnNameAliases, setLocalColumnNameAliases, aliasesReseted])
 
   const dataColumns = useMemo(() => (
     Object.entries(columnsAnalysis).map(([c, { Icon }]) => ({ key: c, icon: Icon }) )
@@ -54,50 +74,67 @@ const ColumnAliasControls = () => {
     <WidgetControlCard
       title={'Column Alias Configuration'}
       type={cardTypes.DOMAIN}
-      clear={() => userUpdate({
-        aliasesReseted: true,
-        columnNameAliases: {},
-        localColumnNameAliases: {},
-      })}
+      clear={() => {
+        setLocalColumnNameAliases({})
+        let clearedAliases = {}
+        Object.keys(columnNameAliases).forEach(key => clearedAliases[key] = '')
+        userUpdate({
+          aliasesReseted: true,
+          columnNameAliases: clearedAliases,
+        })
+      }}
     >
       <>
-        {/* <>
+        <div className={classes.row}>
           <span className={classes.header}>
-            {createElement(Icons.column, { size: 'sm', className: classes.headerIcon })}
+            {createElement(Icons.Columns, { size: 'sm', className: classes.headerIcon })}
             {'Columns'}
           </span>
-          <span className={`${classes.header} ${classes.gridTwoColumns}`}>
-            {createElement(Icons.alias, { size: 'sm', className: classes.headerIcon })}
+          <span className={classes.header}>
+            {createElement(Icons.Alias, { size: 'sm', className: classes.headerIcon })}
             {'Alias'}
           </span>
-        </> */}
-        {dataColumns?.map((col, i) => (
-          <div key={i} className={classes.row}>
-            <div className={classes.columnName}>
-              {createElement(col.icon, { size: 'sm' })}
-              <p className={classes.colKey}>{col.key}</p>
+        </div>
+        {dataColumns?.map((col, i) => {
+          return (
+            <div key={i} className={classes.row}>
+              <div className={classes.columnName}>
+                {createElement(col.icon, { size: 'sm' })}
+                <p className={classes.colKey}>{col.key}</p>
+              </div>
+              <TextField
+                classes={textfieldClasses}
+                size={'md'}
+                value={localColumnNameAliases[col.key]}
+                inputProps={{ placeholder: 'Column title alias' }}
+                onChange={(val) => {
+                  if (Object.values(localColumnNameAliases).includes(val)) {
+                    setAliasError(true)
+                  }
+                  setLocalColumnNameAliases({
+                    ...localColumnNameAliases,
+                    [col.key]: val || '',
+                  })
+                }}
+                error={aliasError}
+                helperText={aliasError && 'Alias is already in use!'}
+              />
             </div>
-            <TextField
-              classes={textfieldClasses}
-              size={'md'}
-              value={localColumnNameAliases[col.key]}
-              inputProps={{ placeholder: 'Column title alias' }}
-              onChange={(val) => {
-                if (Object.values(localColumnNameAliases).includes(val)) {
-                  setAliasError(true)
-                }
-                // userUpdate({ aliasesReseted: false })
-                setLocalColumnNameAliases({
-                  ...localColumnNameAliases,
-                  [col.key]: val || '',
-                })
-              }}
-              // {...{ disabled }}
-              error={aliasError}
-              helperText={aliasError && 'Alias is already in use!'}
-            />
-          </div>
-        ))}
+          )})}
+        <div className={classes.button}>
+          <CustomButton
+            size='sm'
+            variant='filled'
+            onClick={() => {
+              userUpdate({
+                aliasesReseted: true,
+                columnNameAliases: localColumnNameAliases,
+              })
+            }}
+          >
+            submit
+          </CustomButton>
+        </div>
       </>
     </WidgetControlCard>
   )

--- a/src/controls/editor-mode/components/column-alias-controls.js
+++ b/src/controls/editor-mode/components/column-alias-controls.js
@@ -1,70 +1,106 @@
-import React, { useEffect, useState, useMemo } from 'react'
-import PropTypes from 'prop-types'
+import React, { useState, useMemo, createElement } from 'react'
 
-import { useDebounce } from 'use-debounce'
-import { TextField } from '@eqworks/lumen-labs'
-import { useStoreActions, useStoreState } from '../../../store'
+import { TextField, makeStyles, Icons, getTailwindConfigColor } from '@eqworks/lumen-labs'
 
+import { useStoreState, useStoreActions } from '../../../store'
+import WidgetControlCard from '../../shared/components/widget-control-card'
+import cardTypes from '../../../constants/card-types'
+
+
+const classes = makeStyles({
+  row: {
+    display: 'grid',
+    gridTemplateColumns: '50% 50%',
+    marginBottom: '0.25rem',
+    gap: '0.25rem',
+  },
+  columnName: {
+    display: 'flex',
+    gap: '0.5rem',
+    alignItems: 'center',
+    fontSize: '0.786rem',
+    color: getTailwindConfigColor('secondary-800'),
+    backgroundColor: getTailwindConfigColor('secondary-100'),
+    borderRadius: '0.25rem',
+    padding: '0.375rem',
+  },
+  colKey: {
+    overflow: 'hidden',
+  },
+})
 
 const textfieldClasses = Object.freeze({
   container: 'mt-0.5',
 })
 
-const ColumnAliasControls = ({ value, disabled }) => {
-  const userUpdate = useStoreActions((actions) => actions.userUpdate)
+const ColumnAliasControls = () => {
+  // const update = useStoreActions(actions => actions.update)
+  const userUpdate = useStoreActions(actions => actions.userUpdate)
+
+  // const valueKeys = useStoreState((state) => state.valueKeys)
+  const columnsAnalysis = useStoreState((state) => state.columnsAnalysis)
   const columnNameAliases = useStoreState((state) => state.columnNameAliases || {})
-  const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
-  const [alias, setAlias] = useState(columnNameAliases[value])
-  const [debouncedAlias] = useDebounce(value ? alias : '', 300)
-  // indicates if we changed key alias in the current component through onChange
-  const [aliasChanged, setAliasChanged] = useState(false)
+  // const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
+  // const widgetControlCardEdit = useStoreState((state) => state.widgetControlCardEdit)
 
-  useEffect(() => {
-    setAliasChanged(false)
-    setAlias(columnNameAliases[value] || '')
-  }, [aliasesReseted, columnNameAliases, value])
+  const [localColumnNameAliases, setLocalColumnNameAliases] = useState(columnNameAliases)
+  const [aliasError, setAliasError] = useState(false)
 
-  const existingAliases = useMemo(() =>
-    Object.entries(columnNameAliases).filter(([key, val]) => key !== value && val)
-      .map(([, val]) => val.toLowerCase())
-  , [value, columnNameAliases])
-
-  useEffect(() => {
-    if (!aliasesReseted && value && columnNameAliases[value] !== debouncedAlias &&
-      !existingAliases.includes(debouncedAlias) && aliasChanged) {
-      userUpdate({ columnNameAliases: { [value]: debouncedAlias } })
-    }
-  }, [userUpdate, value, debouncedAlias, columnNameAliases, existingAliases, aliasesReseted, aliasChanged])
-
-  const aliasError = useMemo(() => Boolean(value && alias &&
-    existingAliases.includes(alias.toLowerCase())),
-  [value, existingAliases, alias])
+  const dataColumns = useMemo(() => (
+    Object.entries(columnsAnalysis).map(([c, { Icon }]) => ({ key: c, icon: Icon }) )
+  ), [columnsAnalysis])
 
   return (
-    <TextField
-      classes={textfieldClasses}
-      size={'md'}
-      value={alias}
-      inputProps={{ placeholder: 'Column title alias' }}
-      onChange={(val) => {
-        userUpdate({ aliasesReseted: false })
-        setAliasChanged(true)
-        setAlias(val)
-      }}
-      {...{ disabled }}
-      error={aliasError}
-      helperText={aliasError && 'Alias is already in use!'}
-    />
+    <WidgetControlCard
+      title={'Column Alias Configuration'}
+      type={cardTypes.DOMAIN}
+      clear={() => userUpdate({
+        aliasesReseted: true,
+        columnNameAliases: {},
+        localColumnNameAliases: {},
+      })}
+    >
+      <>
+        {/* <>
+          <span className={classes.header}>
+            {createElement(Icons.column, { size: 'sm', className: classes.headerIcon })}
+            {'Columns'}
+          </span>
+          <span className={`${classes.header} ${classes.gridTwoColumns}`}>
+            {createElement(Icons.alias, { size: 'sm', className: classes.headerIcon })}
+            {'Alias'}
+          </span>
+        </> */}
+        {dataColumns?.map((col, i) => (
+          <div key={i} className={classes.row}>
+            <div className={classes.columnName}>
+              {createElement(col.icon, { size: 'sm' })}
+              <p className={classes.colKey}>{col.key}</p>
+            </div>
+            <TextField
+              classes={textfieldClasses}
+              size={'md'}
+              value={localColumnNameAliases[col.key]}
+              inputProps={{ placeholder: 'Column title alias' }}
+              onChange={(val) => {
+                if (Object.values(localColumnNameAliases).includes(val)) {
+                  setAliasError(true)
+                }
+                // userUpdate({ aliasesReseted: false })
+                setLocalColumnNameAliases({
+                  ...localColumnNameAliases,
+                  [col.key]: val || '',
+                })
+              }}
+              // {...{ disabled }}
+              error={aliasError}
+              helperText={aliasError && 'Alias is already in use!'}
+            />
+          </div>
+        ))}
+      </>
+    </WidgetControlCard>
   )
-}
-
-ColumnAliasControls.propTypes = {
-  value: PropTypes.string.isRequired,
-  disabled: PropTypes.bool,
-}
-
-ColumnAliasControls.defaultProps = {
-  disabled: false,
 }
 
 export default ColumnAliasControls

--- a/src/controls/editor-mode/components/column-name-alias.js
+++ b/src/controls/editor-mode/components/column-name-alias.js
@@ -1,0 +1,70 @@
+import React, { useEffect, useState, useMemo } from 'react'
+import PropTypes from 'prop-types'
+
+import { useDebounce } from 'use-debounce'
+import { TextField } from '@eqworks/lumen-labs'
+import { useStoreActions, useStoreState } from '../../../store'
+
+
+const textfieldClasses = Object.freeze({
+  container: 'mt-0.5',
+})
+
+const ColumnNameAlias = ({ value, disabled }) => {
+  const userUpdate = useStoreActions((actions) => actions.userUpdate)
+  const columnNameAliases = useStoreState((state) => state.columnNameAliases || {})
+  const aliasesReseted =  useStoreState((state) => state.aliasesReseted)
+  const [alias, setAlias] = useState(columnNameAliases[value])
+  const [debouncedAlias] = useDebounce(value ? alias : '', 300)
+  // indicates if we changed key alias in the current component through onChange
+  const [aliasChanged, setAliasChanged] = useState(false)
+
+  useEffect(() => {
+    setAliasChanged(false)
+    setAlias(columnNameAliases[value] || '')
+  }, [aliasesReseted, columnNameAliases, value])
+
+  const existingAliases = useMemo(() =>
+    Object.entries(columnNameAliases).filter(([key, val]) => key !== value && val)
+      .map(([, val]) => val.toLowerCase())
+  , [value, columnNameAliases])
+
+  useEffect(() => {
+    if (!aliasesReseted && value && columnNameAliases[value] !== debouncedAlias &&
+      !existingAliases.includes(debouncedAlias) && aliasChanged) {
+      userUpdate({ columnNameAliases: { [value]: debouncedAlias } })
+    }
+  }, [userUpdate, value, debouncedAlias, columnNameAliases, existingAliases, aliasesReseted, aliasChanged])
+
+  const aliasError = useMemo(() => Boolean(value && alias &&
+    existingAliases.includes(alias.toLowerCase())),
+  [value, existingAliases, alias])
+
+  return (
+    <TextField
+      classes={textfieldClasses}
+      size={'md'}
+      value={alias}
+      inputProps={{ placeholder: 'Column title alias' }}
+      onChange={(val) => {
+        userUpdate({ aliasesReseted: false })
+        setAliasChanged(true)
+        setAlias(val)
+      }}
+      {...{ disabled }}
+      error={aliasError}
+      helperText={aliasError && 'Alias is already in use!'}
+    />
+  )
+}
+
+ColumnNameAlias.propTypes = {
+  value: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+}
+
+ColumnNameAlias.defaultProps = {
+  disabled: false,
+}
+
+export default ColumnNameAlias

--- a/src/controls/editor-mode/left-sidebar.js
+++ b/src/controls/editor-mode/left-sidebar.js
@@ -31,7 +31,8 @@ const classes = makeStyles({
 })
 
 const EditorLeftSidebar = () => {
-  const { userUpdate, update } = useStoreActions(actions => actions)
+  const update = useStoreActions(actions => actions.update)
+  const userUpdate = useStoreActions(actions => actions.userUpdate)
 
   const type = useStoreState((state) => state.type)
   const columns = useStoreState((state) => state.columns)
@@ -59,82 +60,91 @@ const EditorLeftSidebar = () => {
           </>
       }
       {/* restrict to dev only for now */}
-      {hasDevAccess() &&
-      <>
-        {type === types.STAT && <TrendControls />}
-        {type === types.STAT && <PercentageControls />}
-        <MutedBarrier mute={!type || !domain.value || !renderableValueKeys.length}>
-          <WidgetControlCard title=''>
-            <div className={classes.row}>
-              {[types.BAR, types.MAP].includes(type) &&
-                <MutedBarrier mute={addTopCategories ||
-                  !((type == types.BAR && numericColumns.length > 1 &&
-                    ((renderableValueKeys.length <= 2 && !addUserControls) || addUserControls)) ||
-                    (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1))}>
-                  {renderToggle(
-                    type === types.MAP ? 'Add Value Controls' : 'Add Benchmark',
-                    addUserControls,
-                    () => userUpdate({ addUserControls: !addUserControls }),
-                    false,
-                    <Tooltip
-                      description={type === types.MAP ?
-                        'Add data value controls on the widget' :
-                        'Benchmark values are unique values used to compare data with.'
-                      }
-                      width='9rem'
-                      arrow={false}
-                      position='right'
-                      classes={{
-                        container: 'mb-0.5',
-                        content: 'overflow-y-visible',
-                      }}
-                    >
-                      <Icons.AlertInformation
-                        size='sm'
-                        color={getTailwindConfigColor('secondary-500')}
-                      />
-                    </Tooltip>
-                  )}
-                </MutedBarrier>
+      {hasDevAccess()
+        && (type === types.STAT
+          || (type === types.BAR &&
+            (Object.values(TOP_COLUMN_KEYS).every(elem => JSON.stringify(columns).includes(elem))
+            || numericColumns.length > 1))
+          || (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1)
+        )
+        &&
+        <>
+          {type === types.STAT && <TrendControls />}
+          {type === types.STAT && <PercentageControls />}
+          {type !== types.STAT
+            && <MutedBarrier mute={!type || !domain.value || !renderableValueKeys.length}>
+              <WidgetControlCard title=''>
+                <div className={classes.row}>
+                  {[types.BAR, types.MAP].includes(type) &&
+                    <MutedBarrier mute={addTopCategories ||
+                      !((type == types.BAR && numericColumns.length > 1 &&
+                        ((renderableValueKeys.length <= 2 && !addUserControls) || addUserControls)) ||
+                        (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1))}>
+                      {renderToggle(
+                        type === types.MAP ? 'Add Value Controls' : 'Add Benchmark',
+                        addUserControls,
+                        () => userUpdate({ addUserControls: !addUserControls }),
+                        false,
+                        <Tooltip
+                          description={type === types.MAP ?
+                            'Add data value controls on the widget' :
+                            'Benchmark values are unique values used to compare data with.'
+                          }
+                          width='9rem'
+                          arrow={false}
+                          position='right'
+                          classes={{
+                            container: 'mb-0.5',
+                            content: 'overflow-y-visible',
+                          }}
+                        >
+                          <Icons.AlertInformation
+                            size='sm'
+                            color={getTailwindConfigColor('secondary-500')}
+                          />
+                        </Tooltip>
+                      )}
+                    </MutedBarrier>
+                  }
+                  {type === types.BAR &&
+                    Object.values(TOP_COLUMN_KEYS).every(elem => JSON.stringify(columns).includes(elem)) &&
+                    <MutedBarrier mute={addUserControls}>
+                      {renderToggle('Add Top Categories',
+                        addTopCategories,
+                        () => {
+                          if (addTopCategories) {
+                            update({ propFilters: [] })
+                          }
+                          userUpdate({ addTopCategories: !addTopCategories })
+                        },
+                        false,
+                        <Tooltip
+                          description={'Add top 10 category controls.'}
+                          width='9rem'
+                          arrow={false}
+                          position='right'
+                          classes={{
+                            container: 'mb-0.5',
+                            content: 'overflow-y-visible',
+                          }}
+                        >
+                          <Icons.AlertInformation
+                            size='sm'
+                            color={getTailwindConfigColor('secondary-500')}
+                          />
+                        </Tooltip>
+                      )}
+                    </MutedBarrier>
+                  }
+                </div>
+              </WidgetControlCard>
+              {((type == types.BAR && numericColumns.length > 1) ||
+                (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1)) &&
+                <UserValueConfigurationControls />
               }
-              {type === types.BAR &&
-                Object.values(TOP_COLUMN_KEYS).every(elem => JSON.stringify(columns).includes(elem)) &&
-                <MutedBarrier mute={addUserControls}>
-                  {renderToggle('Add Top Categories',
-                    addTopCategories,
-                    () => {
-                      if (addTopCategories) {
-                        update({ propFilters: [] })
-                      }
-                      userUpdate({ addTopCategories: !addTopCategories })
-                    },
-                    false,
-                    <Tooltip
-                      description={'Add top 10 category controls.'}
-                      width='9rem'
-                      arrow={false}
-                      position='right'
-                      classes={{
-                        container: 'mb-0.5',
-                        content: 'overflow-y-visible',
-                      }}
-                    >
-                      <Icons.AlertInformation
-                        size='sm'
-                        color={getTailwindConfigColor('secondary-500')}
-                      />
-                    </Tooltip>
-                  )}
-                </MutedBarrier>
-              }
-            </div>
-          </WidgetControlCard>
-          {((type == types.BAR && numericColumns.length > 1) ||
-            (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1)) &&
-            <UserValueConfigurationControls />
+            </MutedBarrier>
           }
-        </MutedBarrier>
-      </>
+        </>
       }
     </EditorSidebarBase>
   )

--- a/src/controls/editor-mode/left-sidebar.js
+++ b/src/controls/editor-mode/left-sidebar.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 
 import { Tooltip, Icons, makeStyles, getTailwindConfigColor } from '@eqworks/lumen-labs'
 
@@ -44,6 +44,15 @@ const EditorLeftSidebar = () => {
   const addTopCategories = useStoreState((state) => state.addTopCategories)
   const renderableValueKeys = useStoreState((state) => state.renderableValueKeys)
 
+  const showAdvancedControls = useMemo(() => hasDevAccess()
+    && (type === types.STAT
+      || (type === types.BAR &&
+        (Object.values(TOP_COLUMN_KEYS).every(elem => JSON.stringify(columns).includes(elem))
+        || numericColumns.length > 1))
+      || (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1)
+    )
+  ,[type, columns, numericColumns, renderableValueKeys])
+
   return (
     <EditorSidebarBase isLeft>
       <DataSourceControls />
@@ -61,14 +70,7 @@ const EditorLeftSidebar = () => {
           </>
       }
       {/* restrict to dev only for now */}
-      {hasDevAccess()
-        && (type === types.STAT
-          || (type === types.BAR &&
-            (Object.values(TOP_COLUMN_KEYS).every(elem => JSON.stringify(columns).includes(elem))
-            || numericColumns.length > 1))
-          || (type == types.MAP && numericColumns.length > 0 && renderableValueKeys.length === 1)
-        )
-        &&
+      {showAdvancedControls &&
         <>
           {type === types.STAT && <TrendControls />}
           {type === types.STAT && <PercentageControls />}

--- a/src/controls/editor-mode/left-sidebar.js
+++ b/src/controls/editor-mode/left-sidebar.js
@@ -16,6 +16,7 @@ import DataTransformationControls from '../shared/data-transformation-controls'
 import PercentageControls from './components/percentage-controls'
 import DataSourceControls from './components/data-source-controls'
 import UserValueConfigurationControls from './components/user-value-configuration-controls'
+import ColumnAliasControls from './components/column-alias-controls'
 import WidgetControlCard from '../shared/components/widget-control-card'
 import { renderToggle } from '../shared/util'
 import TrendControls from './components/trend-controls'
@@ -145,6 +146,9 @@ const EditorLeftSidebar = () => {
             </MutedBarrier>
           }
         </>
+      }
+      {hasDevAccess() &&
+        <ColumnAliasControls/>
       }
     </EditorSidebarBase>
   )

--- a/src/controls/editor-mode/right-sidebar.js
+++ b/src/controls/editor-mode/right-sidebar.js
@@ -16,7 +16,7 @@ import CustomDropdown from './components/custom-dropdown'
 import ExportControls from './components/export-controls'
 import SliderControl from './components/slider-control'
 import EditableSubtitle from '../../view/title-bar/editable-subtitle'
-import ColumnAliasControls from '../editor-mode/components/column-alias-controls'
+import ColumnNameAlias from './components/column-name-alias'
 import { hasDevAccess  } from '../../util/access'
 import { renderItem, renderSection, renderRow, renderToggle, renderSuperSection } from '../shared/util'
 import { positions, sizes, CHART_Z_POSITIONS } from '../../constants/viz-options'
@@ -246,7 +246,7 @@ const EditorRightSidebar = () => {
           }
           {widgetControlCardEdit[cardTypes.RIGHT_SIDEBAR] &&
             renderItem('Pin Tooltip Key Alias',
-              <ColumnAliasControls
+              <ColumnNameAlias
                 value={mapPinTooltipKey?.key || ''}
                 disabled={!hasDevAccess() || !mapPinTooltipKey?.key }
               />

--- a/src/controls/shared/domain-controls.js
+++ b/src/controls/shared/domain-controls.js
@@ -5,7 +5,7 @@ import { Chip, makeStyles } from '@eqworks/lumen-labs'
 import { useStoreState, useStoreActions } from '../../store'
 import CustomSelect from '../../components/custom-select'
 import WidgetControlCard from '../shared/components/widget-control-card'
-import ColumnAliasControls from '../editor-mode/components/column-alias-controls'
+import ColumnNameAlias from '../editor-mode/components/column-name-alias'
 import { renderItem, renderRow } from './util'
 import typeInfo from '../../constants/type-info'
 import cardTypes from '../../constants/card-types'
@@ -138,7 +138,7 @@ const DomainControls = () => {
               </div>}
             {widgetControlCardEdit[cardTypes.DOMAIN] &&
               renderItem('Alias',
-                <ColumnAliasControls
+                <ColumnNameAlias
                   value={domain.value || ''}
                   disabled={!domain.value}
                 />

--- a/src/controls/shared/map-domain-controls.js
+++ b/src/controls/shared/map-domain-controls.js
@@ -5,7 +5,7 @@ import { Icons, Tooltip, makeStyles, getTailwindConfigColor } from '@eqworks/lum
 import { useStoreState, useStoreActions } from '../../store'
 import CustomSelect from '../../components/custom-select'
 import WidgetControlCard from '../shared/components/widget-control-card'
-import ColumnAliasControls from '../editor-mode/components/column-alias-controls'
+import ColumnNameAlias from '../editor-mode/components/column-name-alias'
 import { renderRow, renderItem, renderToggle } from './util'
 import { setMapValueKeys } from '../../util/map-layer-value-functions'
 import { hasDevAccess } from '../../util/access'
@@ -64,7 +64,7 @@ const MapDomainControls = () => {
   ))
 
   const renderAlias = renderItem('Alias', (
-    <ColumnAliasControls
+    <ColumnNameAlias
       value={domain.value || ''}
       disabled={hasDevAccess() && !domain.value}
     />

--- a/src/widget.js
+++ b/src/widget.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
 
-import clsx from 'clsx'
 import { getTailwindConfigColor, makeStyles } from '@eqworks/lumen-labs'
 
 import modes from './constants/modes'
@@ -30,6 +29,14 @@ const commonClasses = {
     justifyContent: 'end',
     alignItems: 'stretch',
   },
+  widgetView: {
+    display: 'flex',
+    flex: '1 1 0%',
+    alignItems: 'stretch',
+    overflow: 'hidden',
+    minWidth: '0',
+    minHeight: '0',
+  },
 }
 
 const useStyles = (mode = modes.EDITOR) => makeStyles(
@@ -41,7 +48,12 @@ const useStyles = (mode = modes.EDITOR) => makeStyles(
         display: 'flex',
         flexDirection: 'column',
         width: '100vw',
-        height: '98%',
+        minHeight: '100%',
+      },
+      editorWidgetView: {
+        position: 'sticky',
+        height: 'calc(100vh - 4rem)',
+        top: '3rem',
       },
       ...commonClasses,
     }
@@ -56,6 +68,9 @@ const useStyles = (mode = modes.EDITOR) => makeStyles(
         height: '100%',
         borderRadius: '0.125rem',
         borderWidth: '2px',
+      },
+      viewMode: {
+        height: '100%',
       },
       ...commonClasses,
     }
@@ -214,9 +229,10 @@ const Widget = ({
   }, [staticData, loadData, dataSourceType, dataSourceID, onInsightsDataRequired, id, type])
 
   const renderView = (
-    <div className={clsx('min-h-0 overflow-hidden flex-1 min-w-0 flex items-stretch', {
-      'h-full': mode === modes.VIEW,
-    })}>
+    <div
+      className={`${classes.widgetView} ${mode === modes.EDITOR && classes.editorWidgetView}
+      ${mode === modes.VIEW && classes.viewMode}`}
+    >
       <WidgetView />
     </div>
   )

--- a/stories/widget.stories.js
+++ b/stories/widget.stories.js
@@ -79,8 +79,8 @@ Object.values(modes).forEach(mode => {
       const renderWidgetAuth = (
         <Authenticated product='locus'>
           <div style={{
-            width: '100vw',
-            height: '100vh',
+            width: '100%',
+            height: '100%',
           }}>
             <Widget {...devProps}
               mode={mode}


### PR DESCRIPTION
https://www.notion.so/eqproduct/Finalize-centralized-column-name-alias-feature-193ffac537644f8b86faa0da8643ccfc?pvs=4

Closes #212

**Changes:**

### Column Alias Configuration
- added a centralized dev-only `Column Alias Configuration` in the left panel to be able to add aliases for all columns in one place
- this would be particular useful when deciding to export all widget data to a CSV file and we need to change several column names in the same time
<img width="1788" alt="Screen Shot 2023-02-24 at 2 22 04 PM" src="https://user-images.githubusercontent.com/41120953/221286765-b93ad7a8-38ed-4c20-9cde-7f32d8dea6d9.png">
- the aliases changed in this feature are not instantaneously updated in the widget state until the Submitted button is pressed. We might change this feature in the future, but only after the formatted column names / aliases are not added to the data objects while changes are taking place, which is the way the process works at the moment
- the feature has validation implemented: if one column key is associated with an existing alias an error message will appear under the affected aliases and the Submit button will be disabled
<img width="1788" alt="Screen Shot 2023-02-24 at 3 44 08 PM" src="https://user-images.githubusercontent.com/41120953/221288422-ca21186b-d298-46b2-8a4b-6cd1169934bd.png">

**Other changes:**
- because the panels on the right & left are really long at the moment, I changed the styling for the central `Widget` to be sticky and not extend vertically beyond the screen extent.

**Recording:**

https://user-images.githubusercontent.com/41120953/221288491-989e9d44-8443-4537-8565-22d76ea18363.mov


**To test:**
1. Login https://6139016b390968003a20da5a-csxtkskalk.chromatic.com/?path=/story/editor-mode--dev-map-1
2. Test in the current map story or any of the other widget stories