### PR TITLE
[G2M] allow title accordion visibility based on editor prop

### DIFF
--- a/src/view/title-bar/index.js
+++ b/src/view/title-bar/index.js
@@ -287,7 +287,7 @@ const WidgetTitleBar = ({ allowOpenInEditor, onOpenInEditor }) => {
           </div>
           {allowOpenInEditor && renderOpenInEditorButton}
         </div>
-        {showTitleBarArrow()}
+        {allowOpenInEditor && showTitleBarArrow()}
       </div>
     )
   }


### PR DESCRIPTION
https://www.notion.so/eqproduct/Set-accordion-to-only-be-useable-by-devs-in-title-to-get-access-to-editor-button-93bb826fbd55482ba6b5dda2e6e777a9