### PR TITLE
[G2M] User controls/fix vis key not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/widget-studio",
-  "version": "0.9.0-alpha.5",
+  "version": "0.9.0-alpha.7",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [


### PR DESCRIPTION
### UserValueControls

**Changes:**
- the api was modified to return only columns that have some values greater than 0, eliminating all the columns that have overall zero values in all postal codes & fsa data for maps
Ref: https://github.com/EQWorks/firstorder/pull/736

**Before:**
- we had columns that had all values 0 resulting in visualizations such as the one below:
<img width="1543" alt="Screen Shot 2023-02-16 at 12 24 10 PM" src="https://user-images.githubusercontent.com/41120953/219441324-6a63892e-dfe3-4d56-b0b6-50bc718cfcdd.png">


**Now:**
- all columns with all values zero are removed & don't appear for selection in the Dropdown Select component
<img width="1543" alt="Screen Shot 2023-02-16 at 12 26 44 PM" src="https://user-images.githubusercontent.com/41120953/219441746-4439071b-99cb-489e-be58-03b56a81625c.png">

**The issue this PR solves:**
- the widgets are configured for a list of column keys to enable visualization for
- but the configured list of keys still appeared in the Dropdown select with the old widget studio version- this is solved now
- if the configured visualization key was not present in the data, we had the issue that the widget was trying to visualize a key values that were not present in data - this is also solved, by selecting the first available key column key in the list that is also present in the data

**Test:**
- go to https://snoke-dashboard-kqo5fdn59-eqworks.vercel.app/1/report?title=Dealer+Market+Area&label=Auto+Insights
- check Dropdown select list for `Vehicle type` tab for .5 & 1km & you will see the lists are different and while the default visualization is set for `Sedan` key in the widget config obj, the visualization key at 5km is set on `Luxury`.





