### PR TITLE
[G2M] Fix stat group/domain filter

### DIFF
--- a/src/constants/columns.js
+++ b/src/constants/columns.js
@@ -10,7 +10,7 @@ export const EXCLUDE_NUMERIC = [
   ...ID_KEYS,
 ]
 
-export const EXCLUDE_NUMERIC_ENDINGS = ['name', 'type', 'id']
+export const EXCLUDE_NUMERIC_ENDINGS = ['name', 'type', '_id', 'Id', 'ID']
 
 export const columnTypes = [
   'Numeric',
@@ -28,7 +28,7 @@ export const columnTypeInfo = {
       const res = !isNaN(v)
       return name === undefined
         ? res
-        : res && !EXCLUDE_NUMERIC_ENDINGS.some(key => name.endsWith('_' + key)) &&
+        : res && !EXCLUDE_NUMERIC_ENDINGS.some(key => name.endsWith(key)) &&
          !EXCLUDE_NUMERIC.includes(name)
     },
   },
@@ -54,7 +54,10 @@ export const columnTypeInfo = {
     ],
     Icon: Icons.Table, // looks like a calendar
     validate: (v, name) => {
-      if (!isString(v) || name.endsWith('_id')) {
+      if (!isString(v) ||
+        EXCLUDE_NUMERIC_ENDINGS.some(key => name.endsWith(key)) ||
+        EXCLUDE_NUMERIC.includes(name)
+      ) {
         return false
       }
       const sample = new Date(v)

--- a/src/constants/type-info.js
+++ b/src/constants/type-info.js
@@ -255,7 +255,7 @@ export default {
   [types.STAT]: {
     icon: Icons.Hash,
     adapter: LocalAdapters[types.STAT],
-    mustGroup: false,
+    mustGroup: true,
     uniqueOptions: {
       selectedTrend: {
         titles: [],
@@ -270,7 +270,7 @@ export default {
   [types.TABLE]: {
     icon: Icons.Table,
     adapter: LocalAdapters[types.TABLE],
-    mustGroup: false,
+    mustGroup: true,
     uniqueOptions: {
       pagination: {
         name: 'Pagination',

--- a/src/controls/editor-mode/components/filters/index.js
+++ b/src/controls/editor-mode/components/filters/index.js
@@ -3,6 +3,7 @@ import React, { useMemo } from 'react'
 import {  Icons } from '@eqworks/lumen-labs'
 
 import { useStoreState, useStoreActions } from '../../../../store'
+import { useGroupFilterValue } from '../../../../hooks/use-group-filter'
 import WidgetControlCard from '../../../shared/components/widget-control-card'
 import { renderSection, renderRow } from '../../../shared/util'
 import PluralLinkedSelect from '../../../../components/plural-linked-select'
@@ -28,6 +29,8 @@ const Filters = () => {
   const dataIsXWIReport = useStoreState((state) => state.dataIsXWIReport)
   const type = useStoreState((state) => state.type)
 
+  const groupFilterValue = useGroupFilterValue()
+
   const filterData = useMemo(() => (
     Object.fromEntries(Object.entries(columnsAnalysis)
       .filter(([, { min, max, isNumeric }]) => isNumeric && min !== max)
@@ -35,17 +38,6 @@ const Filters = () => {
   ), [columnsAnalysis])
 
   const renderGroupFilter = () => {
-    const getGroupFilterValue = () => {
-      if (type === types.STAT) {
-        let _groupFilter = groupFilter
-        if (groups.length === 1) {
-          _groupFilter = groups
-        }
-        return _groupFilter[0] ?? ''
-      }
-      return groupFilter ?? []
-    }
-
     if (domainIsDate) {
       return <DateDomainFilter/>
     }
@@ -55,7 +47,7 @@ const Filters = () => {
         fullWidth
         multiSelect={type === types.STAT ? false : true}
         data={groups}
-        value={getGroupFilterValue()}
+        value={groupFilterValue}
         onSelect={val => userUpdate({ groupFilter: type === types.STAT ? [val] : val })}
         placeholder={group && domain.value ? `Select ${domain.value}(s) to display` : 'N/A'}
         disabled={!group || !domain.value}

--- a/src/controls/editor-mode/components/percentage-controls.js
+++ b/src/controls/editor-mode/components/percentage-controls.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import { useStoreState, useStoreActions } from '../../../store'
 
+import { useGroupFilterValue } from '../../../hooks/use-group-filter'
 import WidgetControlCard from '../../shared/components/widget-control-card'
 import { renderRow } from '../../shared/util'
 import MutedBarrier from '../../shared/muted-barrier'
@@ -15,22 +16,14 @@ const PercentageControls = () => {
 
   const domain = useStoreState((state) => state.domain)
   const type = useStoreState((state) => state.type)
-  const groups = useStoreState((state) => state.groups)
   const renderableValueKeys = useStoreState((state) => state.renderableValueKeys)
-  const groupFilter = useStoreState((state) => state.groupFilter)
   const uniqueOptions = useStoreState((state) => state.uniqueOptions)
   const columns = useStoreState((state) => state.columns)
   const rows = useStoreState((state) => state.rows)
 
   const availableColumns = useMemo(() => columns.map(val => val.name), [columns] )
 
-  const getCurrentGroupFilter = () => {
-    let _groupFilter = groupFilter
-    if (groups.length === 1) {
-      _groupFilter = groups
-    }
-    return _groupFilter
-  }
+  const currentGroupFilter = useGroupFilterValue()
 
   const handleOnSelect = (val) => {
     const values = []
@@ -40,7 +33,7 @@ const PercentageControls = () => {
       const objectKeys = Object.keys(row)
       objectKeys.forEach(k => {
         val.forEach((v, i) => {
-          if (row[domain.value].toString() === getCurrentGroupFilter()[0] && !k.localeCompare(v)) {
+          if (row[domain.value].toString() === currentGroupFilter[0] && !k.localeCompare(v)) {
             if (renderableValueKeys[i].agg) {
               if (!(k in getAggTrendObject)) {
                 getAggTrendObject[k] = []
@@ -67,7 +60,7 @@ const PercentageControls = () => {
   }
 
   return (
-    <MutedBarrier mute={!type || !domain.value || !renderableValueKeys.length || !getCurrentGroupFilter().length}>
+    <MutedBarrier mute={!type || !domain.value || !renderableValueKeys.length || !currentGroupFilter.length}>
       <WidgetControlCard
         title='Percentage Configuration'
         clear={() => resetValue({ uniqueOptions })}

--- a/src/controls/shared/type-controls.js
+++ b/src/controls/shared/type-controls.js
@@ -226,11 +226,11 @@ const WidgetTypeControls = () => {
                           group: mustGroup,
                           ...(
                             mustGroup !== group && {
-                              groupFilter: [],
                               valueKeys: [],
                               ...(domain?.key && { [domain.key]: null }),
                             }
                           ),
+                          groupFilter: [],
                           chart2ValueKeys: [],
                           type,
                           uniqueOptions:

--- a/src/hooks/use-group-filter.js
+++ b/src/hooks/use-group-filter.js
@@ -1,0 +1,23 @@
+import { useStoreState } from '../store'
+import types from '../constants/types'
+
+/**
+ * useGroupFilterValue - determines the value of group filter in the CustomSelect and for percentage
+ *                       calculations for Stat widget
+ * Logic:
+ *  a. default value for Stat Widget is always first element in groups list as Stat widget always
+ *     requires a group filter value in CustomSelect component
+ *  b. otherwise, the filter value is the groupFilter list
+ *  c. we reset the group filter value when we change widget type so we don't create confusion
+ */
+export const useGroupFilterValue = () => {
+  const groups = useStoreState((state) => state.groups)
+  const groupFilter = useStoreState((state) => state.groupFilter)
+  const type = useStoreState((state) => state.type)
+
+  if (type === types.STAT) {
+    let _groupFilter = groupFilter[0] ? groupFilter : groups
+    return [_groupFilter[0] ?? '']
+  }
+  return groupFilter ?? []
+}

--- a/stories/widget.stories.js
+++ b/stories/widget.stories.js
@@ -97,7 +97,7 @@ Object.values(modes).forEach(mode => {
         .add(id, () => (
           mode === modes.EDITOR
             ? <div style={{ width: '100vw', height: '100vh', background: 'white' }}>
-              {['dev-map-1', 'dev-map-2', 'dev-map-4', 'dev-map-5'].includes(id) ?
+              {['dev-stat-1', 'dev-map-1', 'dev-map-2', 'dev-map-4', 'dev-map-5'].includes(id) ?
                 renderWidgetAuth :
                 renderWidget
               }
@@ -106,7 +106,7 @@ Object.values(modes).forEach(mode => {
               style={{ margin: '1rem' }}
               defaultSize={{ width: '50vw', height: '50vh' }}
             >
-              {['dev-map-1', 'dev-map-2', 'dev-map-4', 'dev-map-5'].includes(id) ?
+              {['dev-stat-1','dev-map-1', 'dev-map-2', 'dev-map-4', 'dev-map-5'].includes(id) ?
                 renderWidgetAuth :
                 renderWidget
               }


### PR DESCRIPTION
https://www.notion.so/eqproduct/Fix-groupFilter-for-Stat-widgets-deacbfd878ec446ba48887e8739c1c6c?pvs=4

**Solves:** https://github.com/EQWorks/widget-studio/pull/226#issuecomment-1483400485

**Changes:**
- set `mustGroup = true` for `table` & `stat` widgets 
- create `useGroupFilterValue` to determine value in group filter `CustomSelect` component
- reset `groupFilter` to `[]` when changing widget type

**To test:**
- switch between Stat & any other widget types, back & forth to see changes in group filter in the upper right panel
