### PR TITLE
[G2M] Maps - remove cox GeoJSONMVT & all Cox logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# widget-studio 
+# Widget Studio
 
-System to generate and control widgets, graduated from `ml-ui`
+System to create & configure widgets.
+
+
 
 ## Getting started
 In `widget-studio` project root:
@@ -21,3 +23,104 @@ Navigate to http://localhost:6008 to view the development storybook.
 ![image](https://user-images.githubusercontent.com/53827672/155380165-a9a5bd37-e42e-491b-b423-ebf84ac1a311.png)
 
 ![image](https://user-images.githubusercontent.com/53827672/155380256-95e15dbf-90bc-4a93-9e39-076a8da86452.png)
+
+## Widget component documentation
+
+### Props
+
+- **id** - id of the widget. Defaults is `undefined`.
+- **mode** - Widget Studio's mode. Default is `'editor'`. Options: `['editor', 'ql', 'view_only', 'compact_view_only']`.
+- **wl** - EQ Works's whitelabel. Default is `null`.
+- **cu** - EQ Works's customer. Default is `null`.
+- **staticData** - Defaults is `boolean`.
+- **config** - widget configuration object. [Ref](https://github.com/EQWorks/widget-studio/blob/b9936a7d29d1dc88f1d2a8b9538d8abad6f22906/src/store/model.js#L189). Default is `null`.
+- **rows** - data rows. Default is `null`.
+- **columns** - data columns. Default is `null`.
+- **className** - styling classes. Defaults is `''`
+- **allowOpenInEditor** - whether or not to allow Editor button in Widget view. Defaults to `true`.
+- **onOpenInEditor** - callback to handle opening the widget in Editor. Default is `null`.
+- **onInsightsDataRequired** - callback to pass back `{id, dataSourceID, type}` to parent element. Default is `() => {}`.
+- **saveWithInsightsData** - whether to save or not as an Insights Data- sourced widget. Default is `false`.
+- **dataProviderResponse** - response object from data provider. Default is `{}`.
+- **onWidgetRender** - callback to determine the state of the widget (ie: rendering). Default is `() => {}`.
+- **filters** - data filters. Default is `[]`. Example:
+  ```
+  [{ key: 'resolution', filter: [5000] }]
+  ```
+- **executionID** - execution id. Defaults is `-1`
+- **sampleData** - sample data passed to widget for testing. Defaults to `null`.
+- **sampleConfigs** - list of sample configs for testing. Default is `null`.
+- **mapGroupKey** - map group key. Default is `''`. [Options](https://github.com/EQWorks/widget-studio/blob/96299e2a437a81e895922b8f08cdd9ac6b3fb2bc/src/constants/map.js#L71).
+- **useMVTOption** - whether to use MVT layer in the map when data source is polygons. Default is `null`.
+- **mapTooltipLabelTitles** - column names for the tooltip titles. Default is `null`. Example:
+  ```
+  {
+    sourceTitle: 'poi_name',
+    targetTitle: 'target_poi_name',
+    title: 'poi_id',
+  }
+  ```
+- **customXMapLegendLayerTitles** - labels for layer names in the legend for cross visit maps. Default is `null`. Example:
+  ```
+  {
+    sourceTitle: 'Shop',
+    targetTitle: 'Competitor Shop',
+  }
+  ```
+- **customColors** - custom colors to use in chart and maps. Default is `null`. Example:
+  ```
+  {
+    chart: {
+    color1: ['#004C86', '#CF7047', '#1F7F79', '#B24456', '#582A7D'],
+    color2: [...],
+  },
+    map: {
+      baseColor: '#218CCD',
+      targetLayerColor: '',
+      iconColor: '#CF7047',
+    },
+  }
+  ```
+- **dataFormat** - object of data formatting functions. Default is `null`. Example:
+  ```
+  {
+    years: {
+      keyList: ['Age Group'],
+      formatFunction: (val) => val,
+      formatSymbol: {
+        isPrefix: false,
+        symbol: 'years',
+      },
+    },
+    coxPercentageA: {
+      keyList: [
+        'rate', 'visits',
+      ],
+      formatFunction: (val) => numeral(val / 100).format('0.00%'),
+      formatSymbol: {
+        isPrefix: false,
+        symbol: '%',
+      },
+    },
+  }
+  ```
+- **insightsDataCategories** - categories of data for special category map. Default is `null`. Example:
+  ```
+  {
+    population: [
+      'Total Population',
+      'Male+ Population',
+      'Female+ Population',
+    ],
+    families: [
+      'Lone Parent',
+      'Couple - no Children',
+      'Couple - with Children',
+      'Other',
+    ],
+  }
+  ```
+- **categoryOrder** - list of ordered cateries / columns. Defaults is `null`. Example:
+  ```
+  ['Population', 'Families']
+  ```

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@eqworks/lumen-labs": "^0.1.0-alpha.78",
-    "@eqworks/react-maps": "^0.12.0",
+    "@eqworks/react-maps": "^0.13.0",
     "@material-ui/core": "^4.11.0",
     "@tailwindcss/forms": "^0.5.0",
     "@tailwindcss/postcss7-compat": "^2.1.2",
@@ -48,7 +48,7 @@
     "@babel/preset-react": "^7.10.4",
     "@eqworks/common-login": "^0.9.0-alpha.20",
     "@eqworks/lumen-labs": "^0.1.0-alpha.78",
-    "@eqworks/react-maps": "^0.12.0",
+    "@eqworks/react-maps": "^0.13.0",
     "@material-ui/core": "^4.11.0",
     "@size-limit/preset-small-lib": "^4.5.7",
     "@storybook/addon-actions": "^6.5.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eqworks/widget-studio",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "main": "dist/index.js",
   "source": "src/index.js",
   "files": [

--- a/src/constants/client-specific.js
+++ b/src/constants/client-specific.js
@@ -1,7 +1,0 @@
-// TO DO: remove this once column aliases are implemented for x-walking reports
-export const COX_XWI_KEY_ALIASES = {
-  'poi_id': 'Dealer ID',
-  'target_poi_id': 'Competitor ID',
-  'poi_name': 'Dealer',
-  'target_poi_name': 'Competitor',
-}

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -29,7 +29,7 @@ export const MAP_LAYER_VALUE_VIS = {
   scatterplot: [MAP_VALUE_VIS.fill, MAP_VALUE_VIS.radius],
   targetScatterplot: [MAP_VALUE_VIS.targetFill, MAP_VALUE_VIS.targetRadius],
   geojson: [MAP_VALUE_VIS.fill, MAP_VALUE_VIS.elevation],
-  MVT: [MAP_VALUE_VIS.fill],
+  MVT: [MAP_VALUE_VIS.fill, MAP_VALUE_VIS.elevation],
   arc: [MAP_VALUE_VIS.arcWidth],
   icon: [],
 }

--- a/src/constants/map.js
+++ b/src/constants/map.js
@@ -189,9 +189,6 @@ export const LABEL_OFFSET = {
   polygon: -30,
 }
 
-// 0.5 is an empirical value which controls better when the toast message should be displayed for postal code vis
-export const MAP_TOAST_ZOOM_ADJUSTMENT = 0.5
-
 export const CENSUS_REGEX = {
   postalcode: /^([A-Z][0-9]){3}/g,
   fsa: /^[A-Z][0-9][A-Z]/g,

--- a/src/store/model.js
+++ b/src/store/model.js
@@ -175,6 +175,7 @@ const stateDefaults = [
   { key: 'customColors', defaultValue: {}, resettable: false },
   { key: 'customColorProp', defaultValue: null, resettable: false },
   { key: 'customDataFormat', defaultValue: {}, resettable: false },
+  { key: 'customXMapLegendLayerTitles', defaultValue: {}, resettable: false },
   { key: 'insightsDataCategories', defaultValue: {}, resettable: false },
   { key: 'categoryOrder', defaultValue: [], resetable: false },
 ]
@@ -221,6 +222,7 @@ export default {
       (state) => state.dateAggregation,
       (state) => state.mapTooltipLabelTitles,
       (state) => state.customColors,
+      (state) => state.customXMapLegendLayerTitles,
     ],
     (
       title,
@@ -256,6 +258,7 @@ export default {
       dateAggregation,
       mapTooltipLabelTitles,
       customColors,
+      customXMapLegendLayerTitles,
     ) => ({
       title,
       subtitle,
@@ -291,6 +294,7 @@ export default {
       dateAggregation,
       mapTooltipLabelTitles,
       customColors,
+      customXMapLegendLayerTitles,
     })),
 
   config: computed(

--- a/src/store/model.js
+++ b/src/store/model.js
@@ -178,6 +178,7 @@ const stateDefaults = [
   { key: 'customXMapLegendLayerTitles', defaultValue: {}, resettable: false },
   { key: 'insightsDataCategories', defaultValue: {}, resettable: false },
   { key: 'categoryOrder', defaultValue: [], resetable: false },
+  { key: 'showPostalToast', defaultValue: false, resettable: true },
 ]
 
 export default {

--- a/src/view/adapter/adapters/react-maps.js
+++ b/src/view/adapter/adapters/react-maps.js
@@ -138,7 +138,7 @@ Map.defaultProps = {
 
 export default {
   component: Map,
-  adapt: (data, { wl, mapInitViewState, genericOptions, uniqueOptions, ...config }) => {
+  adapt: (data, { mapInitViewState, genericOptions, uniqueOptions, ...config }) => {
     const {
       mapGroupKey,
       mapValueKeys,
@@ -148,6 +148,7 @@ export default {
       useMVTOption,
       customColors,
       formattedColumnNames,
+      customXMapLegendLayerTitles,
     } = config
     const {
       baseColor,
@@ -252,26 +253,18 @@ export default {
     const targetLayerValueKeys =
       getLayerValueKeys({ mapValueKeys, dataKeys, data: data?.targetData, layer: MAP_LAYERS.targetScatterplot })
 
-    // TO DO: move this logic out to Cox app
     const getFinalLayerTitle = i => {
       let layerTitle
       if (isXWIReportMap) {
-        if (wl === 2456) {
-          layerTitle = i === 0 ? data?.arcData?.[0]?.['poi_name'] || 'Dealer' : 'Competitor'
-        } else {
-          layerTitle = i === 0 ? 'Source Layer' : 'Target Layer'
+        if (i === 0) {
+          layerTitle = data?.arcData?.[0]?.['poi_name'] || customXMapLegendLayerTitles.sourceTitle || 'Source Layer'
+        }
+        else {
+          layerTitle = customXMapLegendLayerTitles.targetTitle || 'Target Layer'
         }
       }
       return layerTitle
     }
-
-    // TO DO: move this logic out to Cox app
-    const finalMapTooltipLabelTitles = wl === 2456 ?
-      {
-        sourceTitle: 'poi_name',
-        targetTitle: 'target_poi_name',
-      } :
-      mapTooltipLabelTitles
 
     let layerConfig = isXWIReportMap ?
       [
@@ -300,8 +293,8 @@ export default {
           interactions: {
             tooltip: {
               tooltipKeys: {
-                tooltipTitle1: finalMapTooltipLabelTitles?.sourceTitle || sourcePOIId,
-                tooltipTitle2: finalMapTooltipLabelTitles?.targetTitle || targetPOIId,
+                tooltipTitle1: mapTooltipLabelTitles?.sourceTitle || sourcePOIId,
+                tooltipTitle2: mapTooltipLabelTitles?.targetTitle || targetPOIId,
                 metricKeys: arcLayerValueKeys,
               },
             },
@@ -352,8 +345,8 @@ export default {
             tooltip: {
               tooltipKeys: {
                 tooltipTitle1: i === 0 ?
-                  finalMapTooltipLabelTitles?.sourceTitle || sourcePOIId :
-                  finalMapTooltipLabelTitles?.targetTitle || targetPOIId,
+                  mapTooltipLabelTitles?.sourceTitle || sourcePOIId :
+                  mapTooltipLabelTitles?.targetTitle || targetPOIId,
                 metricKeys: longitude === targetLon ? targetLayerValueKeys : sourceLayerValueKeys,
               },
             },

--- a/src/view/adapter/adapters/react-maps.js
+++ b/src/view/adapter/adapters/react-maps.js
@@ -27,7 +27,6 @@ import {
   MIN_ZOOM,
   MAX_ZOOM,
   MAP_VIEW_STATE,
-  MAP_TOAST_ZOOM_ADJUSTMENT,
   LABEL_OFFSET,
   ONE_ICON_SIZE,
 } from '../../../constants/map'

--- a/src/view/adapter/adapters/react-maps.js
+++ b/src/view/adapter/adapters/react-maps.js
@@ -32,8 +32,6 @@ import {
   ONE_ICON_SIZE,
 } from '../../../constants/map'
 
-import { COX_XWI_KEY_ALIASES } from '../../../constants/client-specific'
-
 
 const useStyles = ({ width, height, marginTop }) => makeStyles({
   mapWrapper: {
@@ -241,8 +239,7 @@ export default {
           tileGeom: `${process.env.TEGOLA_SERVER_URL || process.env.STORYBOOK_TEGOLA_SERVER_URL}/maps/${mapGroupKeyType}/{z}/{x}/{y}.vector.pbf?`, // <ignore scan-env>
           tileData: data,
         }
-        const elevationVis = JSON.stringify(mapValueKeys)?.includes(MAP_VALUE_VIS.elevation)
-        mapLayer = elevationVis ? mapLayer : MAP_LAYERS.MVT
+        mapLayer = MAP_LAYERS.MVT
       }
     }
 
@@ -313,8 +310,7 @@ export default {
             showLegend: true,
             layerTitle: 'Arc Layer',
           },
-          // TO DO: move this logic out to Cox app
-          keyAliases: wl === 2456 ? COX_XWI_KEY_ALIASES : formattedColumnNames,
+          keyAliases: formattedColumnNames,
           formatDataKey,
           formatDataValue: formatDataFunctions,
           schemeColor: customColors?.map?.baseColor || baseColor.color1,
@@ -366,8 +362,7 @@ export default {
             showLegend: true,
             layerTitle: getFinalLayerTitle(i),
           },
-          // TO DO: move this logic out to Cox app
-          keyAliases: wl === 2456 ? COX_XWI_KEY_ALIASES : formattedColumnNames,
+          keyAliases: formattedColumnNames,
           formatDataKey,
           formatDataValue: formatDataFunctions,
           // we don't apply opacity to icon layer for POI locations
@@ -478,8 +473,7 @@ export default {
               value:  [radiusValue + LABEL_OFFSET.point, 0 - radiusValue - LABEL_OFFSET.point],
             },
           },
-          // TO DO: move this logic out to Cox app
-          keyAliases: wl === 2456 ? COX_XWI_KEY_ALIASES : formattedColumnNames,
+          keyAliases: formattedColumnNames,
           formatDataKey,
           formatDataValue: formatDataFunctions,
           interactions: {},

--- a/src/view/adapter/index.js
+++ b/src/view/adapter/index.js
@@ -59,7 +59,7 @@ const WidgetAdapter = () => {
   const selectedUserDataControlIndex = useStoreState((state) => state.selectedUserDataControlIndex)
   const categoryKeyValues = useStoreState((state) => state.categoryKeyValues)
   const userValueDropdownSelect = useStoreState((state) => state.userValueDropdownSelect)
-  const wl = useStoreState((state) => state.wl)
+  const showPostalToast = useStoreState((state) => state.showPostalToast)
   const mapInitViewState = useStoreState((state) => state.mapInitViewState)
   const { onWidgetRender } = useStoreState((state) => state.ui)
 
@@ -97,9 +97,11 @@ const WidgetAdapter = () => {
   // memoize the correct adapter
   const { component, adapt } = useMemo(() => typeInfo[type].adapter, [type])
 
+  const finalData = useMemo(() => (showPostalToast || !transformedData) ? [] : transformedData, [showPostalToast, transformedData])
+
   // pass the processed data to the rendering adapter and memoize the results
-  const adaptedDataAndConfig = useMemo(() => adapt(transformedData ?? [], { ...config, wl, mapInitViewState, onAfterPlot: onWidgetRender })
-    , [adapt, config, transformedData, wl, mapInitViewState, onWidgetRender])
+  const adaptedDataAndConfig = useMemo(() => adapt(finalData, { ...config, mapInitViewState, onAfterPlot: onWidgetRender })
+    , [adapt, config, mapInitViewState, onWidgetRender, finalData])
 
   // render the component
   return (

--- a/src/widget-manager.js
+++ b/src/widget-manager.js
@@ -473,6 +473,7 @@ const WidgetManager = ({
               mode='editor'
               {...{ wl, cu, saveWithInsightsData, filters, dataFormat, insightsDataCategories,
                 categoryOrder, mapTooltipLabelTitles, customXMapLegendLayerTitles }}
+              mapGroupKey='geo_ca_fsa'
             />
           </CustomModal>
         )
@@ -617,6 +618,7 @@ const WidgetManager = ({
                         {...{ wl, cu, saveWithInsightsData, filters, dataFormat,
                           insightsDataCategories, categoryOrder, mapTooltipLabelTitles, customXMapLegendLayerTitles,
                         }}
+                        mapGroupKey='geo_ca_fsa'
                       />
                     </InsightsDataProvider>
                   }
@@ -627,6 +629,7 @@ const WidgetManager = ({
                         mode='view_only'
                         {...{ filters, wl, cu, dataFormat, insightsDataCategories, categoryOrder,
                           mapTooltipLabelTitles, customXMapLegendLayerTitles }}
+                        mapGroupKey='geo_ca_fsa'
                       />
                   }
                   {!currentlyViewing &&

--- a/src/widget-manager.js
+++ b/src/widget-manager.js
@@ -334,6 +334,8 @@ const WidgetManager = ({
   dataFormat,
   insightsDataCategories,
   categoryOrder,
+  mapTooltipLabelTitles,
+  customXMapLegendLayerTitles,
 }) => {
   const [selectedReport, setSelectedReport] = useState(null)
   const [selectedDashboard, setSelectedDashboard] = useState(null)
@@ -469,7 +471,8 @@ const WidgetManager = ({
             <Widget
               className={classes.newWidget}
               mode='editor'
-              {...{ wl, cu, saveWithInsightsData, filters, dataFormat, insightsDataCategories, categoryOrder }}
+              {...{ wl, cu, saveWithInsightsData, filters, dataFormat, insightsDataCategories,
+                categoryOrder, mapTooltipLabelTitles, customXMapLegendLayerTitles }}
             />
           </CustomModal>
         )
@@ -612,7 +615,7 @@ const WidgetManager = ({
                         id={currentlyViewing}
                         mode='view_only'
                         {...{ wl, cu, saveWithInsightsData, filters, dataFormat,
-                          insightsDataCategories, categoryOrder,
+                          insightsDataCategories, categoryOrder, mapTooltipLabelTitles, customXMapLegendLayerTitles,
                         }}
                       />
                     </InsightsDataProvider>
@@ -622,7 +625,8 @@ const WidgetManager = ({
                         key={currentlyViewing}
                         id={currentlyViewing}
                         mode='view_only'
-                        {...{ filters, wl, cu, dataFormat, insightsDataCategories, categoryOrder }}
+                        {...{ filters, wl, cu, dataFormat, insightsDataCategories, categoryOrder,
+                          mapTooltipLabelTitles, customXMapLegendLayerTitles }}
                       />
                   }
                   {!currentlyViewing &&
@@ -665,6 +669,15 @@ WidgetManager.propTypes = {
   dataFormat: PropTypes.object,
   insightsDataCategories: PropTypes.object,
   categoryOrder: PropTypes.arrayOf(PropTypes.string),
+  customXMapLegendLayerTitles: PropTypes.shape({
+    sourceTitle: PropTypes.string,
+    targetTitle: PropTypes.string,
+  }),
+  mapTooltipLabelTitles: PropTypes.shape({
+    title: PropTypes.string,
+    sourceTitle: PropTypes.string,
+    targetTitle: PropTypes.string,
+  }),
 }
 WidgetManager.defaultProps = {
   wl: -1,
@@ -678,6 +691,8 @@ WidgetManager.defaultProps = {
   dataFormat: null,
   insightsDataCategories: null,
   categoryOrder: null,
+  mapTooltipLabelTitles: null,
+  customXMapLegendLayerTitles: null,
 }
 
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -96,9 +96,10 @@ const Widget = ({
   config: _config,
   sampleData,
   sampleConfigs,
-  mapTooltipLabelTitles,
   mapGroupKey,
   useMVTOption,
+  mapTooltipLabelTitles,
+  customXMapLegendLayerTitles,
   customColors,
   dataFormat,
   insightsDataCategories,
@@ -178,6 +179,7 @@ const Widget = ({
       ...(dataFormat && { customDataFormat: dataFormat }),
       ...(insightsDataCategories && { insightsDataCategories }),
       ...(categoryOrder && { categoryOrder }),
+      ...(customXMapLegendLayerTitles && { customXMapLegendLayerTitles }),
     })
     // use manually passed data if available
     if (_rows?.length && _columns?.length) {
@@ -215,7 +217,7 @@ const Widget = ({
   }, [filters, _columns, _config, _id, _mode, _rows, cu, executionID, id, initDone, loadConfig,
     loadConfigByID, sampleConfigs, sampleData, staticData, update, wl, dataSourceType,
     onInsightsDataRequired, saveWithInsightsData, mapTooltipLabelTitles, mapGroupKey, useMVTOption,
-    onWidgetRender, customColors, dataFormat, insightsDataCategories, categoryOrder])
+    onWidgetRender, customColors, dataFormat, insightsDataCategories, categoryOrder, customXMapLegendLayerTitles])
 
   // load data if source changes
   useEffect(() => {
@@ -289,7 +291,11 @@ Widget.propTypes = {
   onWidgetRender: PropTypes.func,
   saveWithInsightsData: PropTypes.bool,
   dataProviderResponse: PropTypes.object,
-  mapTooltipLabelTitles: PropTypes.object,
+  mapTooltipLabelTitles: PropTypes.shape({
+    title: PropTypes.string,
+    sourceTitle: PropTypes.string,
+    targetTitle: PropTypes.string,
+  }),
   mapGroupKey: PropTypes.string,
   useMVTOption: PropTypes.bool,
   customColors: PropTypes.shape({
@@ -306,6 +312,10 @@ Widget.propTypes = {
   dataFormat: PropTypes.object,
   insightsDataCategories: PropTypes.object,
   categoryOrder: PropTypes.arrayOf(PropTypes.string),
+  customXMapLegendLayerTitles: PropTypes.shape({
+    sourceTitle: PropTypes.string,
+    targetTitle: PropTypes.string,
+  }),
 }
 
 Widget.defaultProps = {
@@ -335,6 +345,7 @@ Widget.defaultProps = {
   dataFormat: null,
   insightsDataCategories: null,
   categoryOrder: null,
+  customXMapLegendLayerTitles: null,
 }
 
 export default withQueryClient(withStore(Widget))

--- a/stories/constants.js
+++ b/stories/constants.js
@@ -108,3 +108,13 @@ export const DATA_KEY_FORMATTING = {
 }
 
 export const CATEGORY_ORDER = ['Top Spending', 'Frequently Transacting']
+
+export const CUSTOM_LEGEND_LAYER_TITLES = {
+  sourceTitle: 'Dealer',
+  targetTitle: 'Competitor',
+}
+
+export const CUSTOM_TOOLTIP_TITLES = {
+  sourceTitle: 'poi_name',
+  targetTitle: 'target_poi_name',
+}

--- a/stories/widget.stories.js
+++ b/stories/widget.stories.js
@@ -15,7 +15,13 @@ import CustomSelect from '../src/components/custom-select'
 import WlCuSelector from './wl-cu-selector'
 import withQueryClient from '../src/util/with-query-client'
 import InsightsDataProvider from '../src/insights-data-provider'
-import { DATA_CATEGORIES, DATA_KEY_FORMATTING, CATEGORY_ORDER } from './constants'
+import {
+  DATA_CATEGORIES,
+  DATA_KEY_FORMATTING,
+  CATEGORY_ORDER,
+  CUSTOM_LEGEND_LAYER_TITLES,
+  CUSTOM_TOOLTIP_TITLES,
+} from './constants'
 
 
 const DEFAULT_WL = 2456
@@ -244,6 +250,8 @@ storiesOf('Widget Management with Insights Data saved configuration', module)
             dataFormat={DATA_KEY_FORMATTING}
             insightsDataCategories={DATA_CATEGORIES}
             categoryOrder={CATEGORY_ORDER}
+            mapTooltipLabelTitles={CUSTOM_TOOLTIP_TITLES}
+            customXMapLegendLayerTitles={CUSTOM_LEGEND_LAYER_TITLES}
           />
         </WlCuControlsProvider>
       </QueryClientProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,10 +1660,10 @@
     react-table "^7.6.0"
     use-cached "^2.0.0"
 
-"@eqworks/react-maps@^0.12.0":
-  version "0.12.0"
-  resolved "https://npm.pkg.github.com/download/@EQWorks/react-maps/0.12.0/e501859694c9a22d712bda773cf48dacd0869dd5#e501859694c9a22d712bda773cf48dacd0869dd5"
-  integrity sha512-ABlT/+tKCllMA/0etLjgFUDFNj/sRgA9e4FNsEQRg7WgOSoOcTfwaIFBHTMbQVmJDZKXo9T/4lKd2Y/1C2aDvA==
+"@eqworks/react-maps@^0.13.0":
+  version "0.13.0"
+  resolved "https://npm.pkg.github.com/download/@EQWorks/react-maps/0.13.0/da2fad3a2316ba1cd3d1ff998a904f0811eca284#da2fad3a2316ba1cd3d1ff998a904f0811eca284"
+  integrity sha512-e9uHZyv+/YGSS3EuVwYZerio8dF6qx8XxNqiTisLxBRXpTzN7CwJW84yLrVvyR6UTp1AzNjep1zVqVsrca2qPA==
   dependencies:
     "@deck.gl/aggregation-layers" "^8.7.5"
     "@deck.gl/core" "^8.7.5"
@@ -1683,7 +1683,6 @@
     "@turf/circle" "^6.5.0"
     "@turf/distance" "^6.5.0"
     "@turf/helpers" "^6.5.0"
-    "@turf/union" "^6.5.0"
     d3-array "^3.1.1"
     d3-color "^3.0.1"
     d3-scale "^4.0.2"
@@ -4026,7 +4025,7 @@
     "@turf/meta" "^6.5.0"
     "@turf/rhumb-destination" "^6.5.0"
 
-"@turf/union@>=4.0.0", "@turf/union@^6.5.0":
+"@turf/union@>=4.0.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/union/-/union-6.5.0.tgz#82d28f55190608f9c7d39559b7f543393b03b82d"
   integrity sha512-igYWCwP/f0RFHIlC2c0SKDuM/ObBaqSljI3IdV/x71805QbIvY/BYGcJdyNcgEA6cylIGl/0VSlIbpJHZ9ldhw==


### PR DESCRIPTION
**Changes:**
- removed GeoJSONMVT logic
- removed all COX-related code
- added new props to Widget ( mapTooltipLabelTitles, customXMapLegendLayerTitles )
- added prop description for Widget component in Readme.

To test: https://snoke-dashboard-git-widget-prop-updates-eqworks.vercel.app/1/report?title=Cross+Visitation
- all maps should show `FSA `or `Postal Code` for titles
- cross visitation Map above should read in Legend: `name of the Dealer` for source & `Competitor` for target layer. Tooltip should contain `Dealer` and / or `Competitor` titles when hovering on circles & arcs.

<img width="1675" alt="reg map" src="https://github.com/EQWorks/widget-studio/assets/41120953/541b8f8f-5bf7-4d39-b61d-bb2148fbe177">

<img width="1485" alt="cross map" src="https://github.com/EQWorks/widget-studio/assets/41120953/3b4256be-21e7-4f8d-b29f-e56ac6ed1fa0">

